### PR TITLE
Added support for paths with spaces

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -76,7 +76,7 @@ function logs() {
 
 # =================================================================================================================
 
-pushd ${SCRIPT_HOME} >/dev/null
+pushd "${SCRIPT_HOME}" >/dev/null
 COMMAND=$(toLower ${1})
 shift || COMMAND=usage
 


### PR DESCRIPTION
`./manage start` gives the following error `./manage: line 79: pushd: too many arguments` if path has spaces.