### PR TITLE
Dockerized tails-server now bases on newer version of von-image.

### DIFF
--- a/docker/Dockerfile.tails-server
+++ b/docker/Dockerfile.tails-server
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:next-1
+FROM bcgovimages/von-image:py36-1.16-0
 
 ADD requirements.txt .
 ADD requirements.dev.txt .

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ base58
 # temporary to fix transitive dependency issues
 multidict<5.0.0
 yarl==1.6.0
+indy_vdr~=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ if __name__ == "__main__":
         package_data={"tails_server": ["requirements.txt"]},
         install_requires=parse_requirements("requirements.txt"),
         tests_require=parse_requirements("requirements.dev.txt"),
-        python_requires=">=3.7.0",
+        python_requires=">=3.6.3",
         classifiers=[
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.6",
             "License :: OSI Approved :: Apache Software License",
             "Operating System :: OS Independent",
         ],


### PR DESCRIPTION
 Applied change to run with Python 3.6. Also include indy_vdr. All changes were suggested in issue#17.