### PR TITLE
Updated fix for cffi build error.

### DIFF
--- a/docker/Dockerfile.tails-server
+++ b/docker/Dockerfile.tails-server
@@ -1,18 +1,9 @@
 FROM bcgovimages/von-image:next-1
 
-ARG user=indy
-USER root
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    build-essential \
-    libffi-dev \
-    python3-dev && \
-    rm -rf /var/lib/apt/lists/*
-USER $user
-
 ADD requirements.txt .
 ADD requirements.dev.txt .
 
+RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir -r requirements.txt -r requirements.dev.txt
 
 ADD tails_server ./tails_server

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,18 +1,9 @@
 FROM bcgovimages/von-image:next-1
 
-ARG user=indy
-USER root
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
-    build-essential \
-    libffi-dev \
-    python3-dev && \
-    rm -rf /var/lib/apt/lists/*
-USER $user
-
 ADD requirements.txt .
 ADD requirements.dev.txt .
 
+RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir -r requirements.txt -r requirements.dev.txt
 
 ADD test ./

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,3 @@
 rich
-cffi==1.14.6
 pynacl
 aiofiles


### PR DESCRIPTION
- The updated version of `pip` is able to find the wheel(s) for the updated version of `PyNaCl`.  Therefore cffi does not need to be built.
- This provides a significant improvement in the build time for the images.

Signed-off-by: Wade Barnes <wade@neoterictech.ca>