### PR TITLE
Update base image for tails-server from von-image to Python to simplify the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,19 @@ This software is designed to support scaling to as many machines or processes as
 
 ## Tests
 
-There is a suite of integration tests that test some assumptions about the environment like the type of mounted file system and the ledger that is being connected to. For running these tests a local von-network needs to be running and the seed `00000000000000000000000000000000` needs to be registered with Endorser role on the von-network.
-From the docker directory, run `./manage test`.
+There is a suite of integration tests that test some assumptions about the environment like the type of mounted file system and the ledger that is being connected to. For running these tests a local von-network needs to be running, you can spin one up by 
+```
+git clone https://github.com/bcgov/von-network
+cd von-network
+./manage build
+./manage start
+```
+After the von-network is up, goto the tails-server docker directory, run the manage script as follows.
+```
+cd indy-tails-server/docker
+./manage test
+```
+This will perform a series of tests creating revocation registries with a local tails-server.
 
 ## Additional Notes
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ This software is designed to support scaling to as many machines or processes as
 
 ## Tests
 
-There is a suite of integration tests that test some assumptions about the environment like the type of mounted file system and the ledger that is being connected to. From the docker directory, run `./manage test`.
+There is a suite of integration tests that test some assumptions about the environment like the type of mounted file system and the ledger that is being connected to. For running these tests a local von-network needs to be running and the seed `00000000000000000000000000000000` needs to be registered with Endorser role on the von-network.
+From the docker directory, run `./manage test`.
 
 ## Additional Notes
 

--- a/docker/Dockerfile.tails-server
+++ b/docker/Dockerfile.tails-server
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:next-1
+FROM python:3.9
 
 ADD requirements.txt .
 ADD requirements.dev.txt .

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM bcgovimages/von-image:next-1
+FROM python:3.9
 
 ADD requirements.txt .
 ADD requirements.dev.txt .

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM bcgovimages/von-image:next-1
 
 ADD requirements.txt .
 ADD requirements.dev.txt .

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,5 @@
 rich
 pynacl
 aiofiles
+
+python3_indy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ base58
 # temporary to fix transitive dependency issues
 multidict<5.0.0
 yarl==1.6.0
+
+indy_vdr


### PR DESCRIPTION
This PR is to update the base image used for running the tails-server docker container from von-image to Python3.9. I have also added the missing dependencies `indy_vdr` and `python3_indy` to include in requirements and requirements.dev to run the server and tests.
Looking for feedback from the community.