### PR TITLE
Error loading library: indy_vdr specified version because it occurs when installing as pip3 install indy-vdr.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ base58
 multidict<5.0.0
 yarl==1.6.0
 
-indy_vdr
+# indy_vdr
+# Error loading library: indy_vdr specified version because it occurs when installing as pip3 install indy-vdr.
+indy_vdr==0.4.0.dev1


### PR DESCRIPTION
An error occurs while installing indy_vdr when running a demo.
Verified normal operation if the version is specified.
This request specifies the version of indy_vdr