### PR TITLE
Update Dockerfile.tails-server with setuptools upgrade

### DIFF
--- a/docker/Dockerfile.tails-server
+++ b/docker/Dockerfile.tails-server
@@ -5,6 +5,7 @@ ADD requirements.dev.txt .
 
 RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir -r requirements.txt -r requirements.dev.txt
+RUN pip3 install --upgrade setuptools
 
 ADD tails_server ./tails_server
 ADD bin ./bin


### PR DESCRIPTION
- Qualys scanning failed for setuptools vulnerability issue. 

- setuptools version was setuptools-58.1.0

- we upgraded to latest version (71.1.0). 

- Add following line into Docker file to update the setuptools.

    `RUN pip3 install --upgrade setuptools`

Following link is for setuptools vulnerability.
https://ubuntu.com/security/CVE-2024-6345