### PR TITLE
Bump dependencies, use Python 3.12

### DIFF
--- a/docker/Dockerfile.tails-server
+++ b/docker/Dockerfile.tails-server
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.12
 
 ADD requirements.txt .
 ADD requirements.dev.txt .

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-rich~=13.7.0
+rich~=13.8.1
 pynacl~=1.5.0
 aiofiles~=23.2.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-aiohttp==3.9.5
+aiohttp==3.10.5
 base58~=2.1.1
 
 # temporary to fix transitive dependency issues
 multidict<5.0.0
-yarl==1.6.0
+yarl==1.11.1
 
 # indy_vdr
 # Error loading library: indy_vdr specified version because it occurs when installing as pip3 install indy-vdr.

--- a/tails_server/args.py
+++ b/tails_server/args.py
@@ -16,7 +16,7 @@ PARSER.add_argument(
 
 PARSER.add_argument(
     "--port",
-    type=str,
+    type=int,
     required=False,
     dest="port",
     metavar="<port>",
@@ -38,7 +38,7 @@ PARSER.add_argument(
     required=False,
     dest="log_level",
     metavar="<log_level>",
-    help="Specify your desired loging level.",
+    help="Specify your desired logging level.",
 )
 
 PARSER.add_argument(


### PR DESCRIPTION
I started with the intention of restructuring the project to use Poetry and fully update it, however it seems to be more complicated than I anticipated.

This PR will bump dependencies and update the runtime to use python 3.12, however the test runner has to stay on python 3.9 since the dependency on indy (which requires ubuntu 20.04) makes things a bit more complicated.