### PR TITLE
Ensure backward compatibility for logging configuration

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -13,7 +13,7 @@ if [[ $(docker compose version 2> /dev/null) == 'Docker Compose'* ]]; then
 fi
 export MSYS_NO_PATHCONV=1
 # getDockerHost; for details refer to https://github.com/bcgov/DITP-DevOps/tree/main/code/snippets#getdockerhost
-. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))" 
+. /dev/stdin <<<"$(cat <(curl -s --raw https://raw.githubusercontent.com/bcgov/DITP-DevOps/main/code/snippets/getDockerHost))"
 export DOCKERHOST=$(getDockerHost)
 set -e
 
@@ -57,7 +57,7 @@ exportEnvironment() {
 
   export GENESIS_URL=${GENESIS_URL:-http://$DOCKERHOST:9000/genesis}
   export STORAGE_PATH=${STORAGE_PATH:-/tmp/tails-files}
-  export LOG_LEVEL=${LOG_LEVEL:-INFO}
+  export LOG_LEVEL=${LOG_LEVEL:-info}
   export LOGGING_CONFIG=${LOGGING_CONFIG:-/tails_server/config/logging-config.yml}
   export TAILS_SERVER_URL=${TAILS_SERVER_URL:-http://$DOCKERHOST:6543}
 }
@@ -70,7 +70,7 @@ function logs() {
     while getopts ":f-:" FLAG; do
       case $FLAG in
         f ) local _force=1 ;;
-        - ) 
+        - )
             case ${OPTARG} in
                 "no-tail"*) no_tail=1
               ;;
@@ -102,7 +102,7 @@ start|up)
   exportEnvironment "$@"
   ${dockerCompose} up -d ngrok-tails-server tails-server
   logs
-  echo "Run './manage logs' for logs" 
+  echo "Run './manage logs' for logs"
   ;;
 test)
   exportEnvironment "$@"

--- a/tails_server/args.py
+++ b/tails_server/args.py
@@ -29,8 +29,7 @@ PARSER.add_argument(
     required=False,
     dest="log_level",
     metavar="<log_level>",
-    choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
-    default="INFO",
+    default="info",
     help="Python3 logging library level",
 )
 


### PR DESCRIPTION
- Remove restriction on `--log-level` command line option.  Case does not matter.  e.g. `INFO` and `info` are treated the same.

This fixes the issue identified here; https://github.com/bcgov/indy-tails-server/pull/111#discussion_r2261101434